### PR TITLE
Test STM8S207RBT6

### DIFF
--- a/test/blink-stm8.fth
+++ b/test/blink-stm8.fth
@@ -1,5 +1,3 @@
-include target/nucleus.fth
-
 5005 constant pb_odr
 5007 constant pb_ddr
 5008 constant pb_cr1


### PR DESCRIPTION
I got a STM8S207RBT6 board.  It was recommended by @TG9541, thanks!  It's a performance STM8S with plenty of room: 128K flash, 6K RAM, and 2K EEPROM.