### PR TITLE
Added support for interrupt in atmega328p

### DIFF
--- a/src/compiler.fth
+++ b/src/compiler.fth
@@ -22,6 +22,7 @@ include target/asm.fth
 : header, ( a u -- ) here t-word  here to latest ;
 
 include target/x1.fth
+include target/avr/interrupt.fth
 
 also forth
 ' comp, is t-compile,
@@ -39,6 +40,7 @@ h: end-code   previous ;
 only forth also meta also compiler definitions previous
 include target/x2.fth
 
+h: int;   [compile] exitint [compile] [ ;
 h: ;   [compile] exit [compile] [ ;
 h: [']   ' t-literal ;
 h: [char]   char t-literal ;

--- a/target/avr/asm.fth
+++ b/target/avr/asm.fth
@@ -283,7 +283,7 @@ drop
 
 : 3swap   >r rot >r 2swap 2r> >r -rot r> ;
 : else,   ahead, 3swap then, ;
-: while,   >r if, r> ;
+: while,  swap >r if, r> ;
 : repeat,   again, then, ;
 
 \ Runtime for ;CODE.  CODE! is defined elsewhere.

--- a/target/avr/interrupt.fth
+++ b/target/avr/interrupt.fth
@@ -1,0 +1,17 @@
+
+also assembler
+
+: isr!  ( xt n - ) ( compile jmp instruction to isr routine )
+    4 * t-image +           ( xt adr0 - )
+    dup                     ( xt adr0 adr0 - )
+    12 swap c!              ( xt adr0 - )
+    1+                      ( xt adr1 - )
+    dup                     ( xt adr1 adr1 - )
+    148 swap c!             ( xt adr1 - )
+    1+                      ( xt adr2 - )
+    over 1 rshift over c!   ( xt adr2 - )
+    1+                      ( xt adr3 - )
+    swap 9 rshift swap c!
+;
+
+previous

--- a/target/avr/nucleus.fth
+++ b/target/avr/nucleus.fth
@@ -1,13 +1,29 @@
-code cold
-   ahead, \ Interrupt vectors.
+code iv,
+   ahead, nop, \ Interrupt vectors. atmeba328p each IV = 2 instructions, 26 interrupt vectors => 52 cells (ahead, + nop, = reset; + 25IV)
    nop, nop, nop, nop, nop, nop, nop, nop,
    nop, nop, nop, nop, nop, nop, nop, nop,
-   then,
+   nop, nop, nop, nop, nop, nop, nop, nop,
+   nop, nop,
+   nop, nop, nop, nop, nop, nop, nop, nop,
+   nop, nop, nop, nop, nop, nop, nop, nop,
+   nop, nop, nop, nop, nop, nop, nop, nop,
+end-code
 
-   140 # r28 ldi, \ Set data stack pointer.
+code cold,
+   then,
+(   140 # r28 ldi, \ Set data stack pointer. Problem s pretekanim!!!! zmenit pocatky OBOUT stacků
    r29 clr,
    158 # r16 ldi,
-   61 r16 out, \ Set return stack pointer.
+   61 r16 out, \ Set return stack pointer. )
+
+   255 # r28 ldi, \ Set data stack pointer to 3/4 of ram
+   6 # r29 ldi,
+
+   255 # r16 ldi,  \ Set return stack pointer to ram end
+   61 r16 out,
+   8 # r16 ldi,
+   62 r16 out,
+
    ahead, \ Jump to WARM.
 end-code
 
@@ -164,6 +180,33 @@ code 0<
      ret,
   then,
 end-code
+
+code swr
+   -y r27 st,
+   63 r27 in,
+   -y r27 st,
+   -y r26 st,
+   -y r3 st,
+   -y r2 st,
+   -y r31 st,
+   -y r30 st,
+   ret,
+end-code
+
+code rwr
+   y+ r30 ld,
+   y+ r31 ld,
+   y+ r2 ld,
+   y+ r3 ld,
+   y+ r26 ld,
+   y+ r27 ld,
+   63 r27 out,
+   y+ r27 ld,
+   ret,
+end-code
+
+
+
 
 : r@   r> r> dup >r swap >r ;
 : =   - [  \ Fall through.

--- a/target/avr/params.fth
+++ b/target/avr/params.fth
@@ -1,5 +1,5 @@
 1 constant t-little-endian
 2 constant t-cell
 0 constant program-start
-hex 60 constant data-start
+hex 100 constant data-start
 decimal

--- a/target/avr/x2.fth
+++ b/target/avr/x2.fth
@@ -1,5 +1,6 @@
 also assembler
 h: exit   ret, ;
+h: exitint  reti, ;
 h: nip   2 # r28 adiw, ;
 h: cell+   2 # r26 adiw, ;
 h: 1+   1 # r26 adiw, ;

--- a/test/interrupt-atmega328.fth
+++ b/test/interrupt-atmega328.fth
@@ -1,0 +1,26 @@
+: DDRCOUT 255 39 c! ;
+
+: PORTCON 255 40 c! ;
+
+: PORTCOFF 0 40 c! ;
+
+: DDRBOUT 255 36 c! ;
+
+: PORTBON 255 37 c! ;
+
+: PORTBOFF 0 37 c! ;
+
+: 1MS 300 begin 1- dup 0= until drop ;
+
+: MS begin 1MS 1- dup 0= until drop ;
+
+: SETUPISR  12 105 c! 2 61 c! 128 95 c! ;
+
+: myisr swr 37 c@ 255 xor 37 c! 500 MS rwr int;
+
+variable abcd
+
+: abc then  5 abcd ! 15 DDRCOUT DDRBOUT SETUPISR 3000 MS begin 1000 MS PORTCON 1000 MS PORTCOFF again ;
+
+' myisr 2 isr!
+


### PR DESCRIPTION
Edited for atega328p (edited nucleus.fth for correct interrupt vectors size and changet position of return stack to end of ram and data stack to 3/4 od ram, edited params.fth for correct data ram start). Implemetend spuport for interrupt (in interrupt.fth and in nucleus.fth - swr = save working registers, rwr = restore working registers). Example is in test/interrupt-atmega328.fth